### PR TITLE
fix: url ordering

### DIFF
--- a/anp_examples/simple_example.py
+++ b/anp_examples/simple_example.py
@@ -271,7 +271,7 @@ async def simple_crawl(
     result = {
         "content": response_message.content,
         "type": "text",
-        "visited_urls": list(visited_urls),
+        "visited_urls": [doc["url"] for doc in crawled_documents],
         "crawled_documents": crawled_documents,
         "task_type": task_type,
     }


### PR DESCRIPTION
***Summary:** The "Visited URLs" in the UI don't consistently match the order in which they were actually crawled.*

**Root Cause:** The problem occurs because we're using a Python set to track visited URLs in the `simple_crawl` function. Sets in Python don't maintain insertion order. When this set is converted to a list in the final response, the order of URLs is arbitrary rather than chronological.
```python
"visited_urls": list(visited_urls)
```

**Solution:** Instead of using the unordered set for the final output, we extract URLs from the `crawled_documents` list, which already maintains the proper crawling order:
```python
"visited_urls": [doc["url"] for doc in crawled_documents]
```
This approach maintains the efficiency of using sets for duplicate checking during crawling.

**Testing:** I verified this fix by running multiple searches and confirming the URLs are now consistently displayed in the same order they appear in the logs.